### PR TITLE
modified description and italian annotations

### DIFF
--- a/prod.ttl
+++ b/prod.ttl
@@ -48,13 +48,13 @@ foaf:name a owl:DatatypeProperty .
     owl:versionInfo "v0.1.0" ;
     #owl:priorVersion <https://w3id.org/product/product-0.1.0> ;
     dcterms:title "PRODUCT: PRODUCT ontology "@en ;
-    dcterms:description """The PRODUCT Ontology (PRODUCT) extends the Building Topology Ontology (BOT) with more specific building elements."""@en ;
+    dcterms:description """The PRODUCT Ontology (PRODUCT) defines articles and substances that can be employed in the Architecture, Engineering, and Construction (AEC) and Facility Management (FM) industry."""@en ;
     dcterms:creator [a foaf:Person ; foaf:name "Mads Holten Rasmussen" ] ;
     dcterms:creator [a foaf:Person ; foaf:name "Pieter Pauwels" ] ;
     dcterms:contributor [a foaf:Person ; foaf:name "Maxime Lefrançois" ] ;
     dcterms:contributor [a foaf:Person ; foaf:name "Georg Ferdinand Schneider" ] ;
     dcterms:contributor [a foaf:Person ; foaf:name "Gonçal Costa" ] ;
-    #dcterms:contributor [a foaf:Person ; foaf:name "" ] ;
+    dcterms:contributor [a foaf:Person ; foaf:name "Walter Terkaj" ] ;
     dcterms:license <https://creativecommons.org/licenses/by/1.0/> ;
     vann:preferredNamespacePrefix "product" ;
     vann:preferredNamespaceUri <https://w3id.org/product#> ;
@@ -69,10 +69,12 @@ product:Product
         a owl:Class ;
         rdfs:label      "Product"@en ,
                         "Product"@nl ,
-                        "Produkt"@da ;
+                        "Produkt"@da ,
+			"Prodotto"@it;
         rdfs:comment    "A product is an article or substance that is manufactured or refined for sale"@en ,
-						"Een product is een artikel of substantie die aangemaakt of bijgewerkt wordt voor verkoop"@nl ,
-                        "Et produkt er en artikel eller substans som er fremstillet eller rafineret til salg"@da .
+			"Een product is een artikel of substantie die aangemaakt of bijgewerkt wordt voor verkoop"@nl ,
+                        "Et produkt er en artikel eller substans som er fremstillet eller rafineret til salg"@da ,
+			"Un prodotto è un articolo o sostanza che ha subito una lavorazione o elaborazione a scòpo di vendita"@it.
 
 #################################
 # OBJECT PROPERTIES


### PR DESCRIPTION
- broader scope in the dcterms:description of the ontology, more consistent with the current dce:description
- removed the statement that the "Product ontology extends the BOT ontology", since it is still to be agreed upon
- added italian annotations for product:Product